### PR TITLE
Custom installations of Gmsh via Preferences.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
           version: ${{ matrix.version }}
       - uses: julia-actions/julia-buildpkg@v1
       - name: Install Gmsh SDK dependencies
-          run: sudo apt-get install -y libglu1-mesa
+        run: sudo apt-get install -y libglu1-mesa
       - name: Install Gmsh SDK
         run: |
           curl -OL https://gmsh.info/bin/Linux/gmsh-4.12.2-Linux64-sdk.tgz

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
       - run: |
             julia --project=. -e '
             using Gmsh
-            using Gmsh.use_system_binary(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib")
+            Gmsh.use_system_binary(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib")
             '
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           file: lcov.info
   test-custom-gmsh:
-    name: Custom Gmsh installation with Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Custom Gmsh with Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -51,13 +51,16 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/julia-buildpkg@v1
-      - run: curl -OL https://gmsh.info/bin/Linux/gmsh-4.12.2-Linux64-sdk.tgz
-      - run: tar xvf gmsh-4.12.2-Linux64-sdk.tgz
-      - run: |
-            julia --project=. -e '
+      - name: install gmsh sdk
+        run: |
+          curl -OL https://gmsh.info/bin/Linux/gmsh-4.12.2-Linux64-sdk.tgz
+          tar xvf gmsh-4.12.2-Linux64-sdk.tgz
+          mv gmsh-4.12.2-Linux64-sdk /opt/
+      - name: configure Gmsh preferences
+        shell: julia --color=yes --project=. {0}
+        run: |
             using Gmsh
-            Gmsh.use_system_gmsh(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib")
-            '
+            Gmsh.use_system_gmsh(;gmsh_jl_dir="/opt/gmsh-4.12.2-Linux64-sdk/lib")
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+  test-custom-gmsh:
     name: Custom Gmsh installation with Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,8 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Install Gmsh SDK dependencies
+          run: sudo apt-get install -y libglu1-mesa
       - name: Install Gmsh SDK
         run: |
           curl -OL https://gmsh.info/bin/Linux/gmsh-4.12.2-Linux64-sdk.tgz

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,3 +36,28 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+    name: Custom Gmsh installation with Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - run: curl -OL https://gmsh.info/bin/Linux/gmsh-4.12.2-Linux64-sdk.tgz
+      - run: tar xvf gmsh-4.12.2-Linux64-sdk.tgz
+      - run: |
+            julia --project=. -e '
+            using Gmsh
+            using Gmsh.use_system_binary(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib") '
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           file: lcov.info
   test-custom-gmsh:
-    name: Custom Gmsh with Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    name: Gmsh SDK - Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -51,12 +51,12 @@ jobs:
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/julia-buildpkg@v1
-      - name: install gmsh sdk
+      - name: Install Gmsh SDK
         run: |
           curl -OL https://gmsh.info/bin/Linux/gmsh-4.12.2-Linux64-sdk.tgz
           tar xvf gmsh-4.12.2-Linux64-sdk.tgz
           mv gmsh-4.12.2-Linux64-sdk /opt/
-      - name: configure Gmsh preferences
+      - name: Configure Gmsh preferences
         shell: julia --color=yes --project=. {0}
         run: |
             using Gmsh

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
       - run: |
             julia --project=. -e '
             using Gmsh
-            Gmsh.use_system_binary(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib")
+            Gmsh.use_system_gmsh(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib")
             '
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,8 @@ jobs:
       - run: |
             julia --project=. -e '
             using Gmsh
-            using Gmsh.use_system_binary(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib") '
+            using Gmsh.use_system_binary(;gmsh_jl_dir="gmsh-4.12.2-Linux64-sdk/lib")
+            '
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ authors = ["Jukka Aho <ahojukka5@gmail.com>"]
 version = "0.3.1"
 
 [deps]
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 gmsh_jll = "630162c2-fc9b-58b3-9910-8442a8a132e6"
 
 [compat]
+Preferences = "1"
 gmsh_jll = "4.11"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Jukka Aho <ahojukka5@gmail.com>"]
 version = "0.3.1"
 
 [deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 gmsh_jll = "630162c2-fc9b-58b3-9910-8442a8a132e6"
 

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -36,13 +36,15 @@ export gmsh
 @static if gmsh_provider == "system"
     using Libdl
     function __init__()
+        # This is just to have a better idea why gmsh.lib is empty
         @static if Sys.isunix()
-            @show gmsh.libdir
-            @show gmsh.libname
-            @show gmsh.lib
-            gmsh_lib = joinpath(gmsh_jl_dir,"libgmsh.so")
-            @show gmsh_lib
-            Libdl.dlopen(gmsh_lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
+            if gmsh.lib == ""
+                gmsh_lib = joinpath(gmsh_jl_dir,"libgmsh")
+                Libdl.dlopen(gmsh_lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
+            end
+        end
+        if gmsh.lib == ""
+            error("The gmsh.jl API file was not able to find a gmsh libary. Some dependencies are provably not installed in the system.")
         end
     end
 end

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -35,6 +35,7 @@ include(gmsh_api)
     using Libdl
     # The definition of __init__ is taken from GridapGmsh.jl
     function __init__()
+        @show Sys.isunix()
         @static if Sys.isunix()
             Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
         end

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -37,8 +37,12 @@ export gmsh
     using Libdl
     function __init__()
         @static if Sys.isunix()
+            @show gmsh.libdir
+            @show gmsh.libname
             @show gmsh.lib
-            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
+            gmsh_lib = joinpath(gmsh_jl_dir,"libgmsh.so")
+            @show gmsh_lib
+            Libdl.dlopen(gmsh_lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
         end
     end
 end

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -33,14 +33,15 @@ include(gmsh_api)
 import .gmsh
 export gmsh
 
-#@static if gmsh_provider == "system"
-#    using Libdl
-#    function __init__()
-#        @static if Sys.isunix()
-#            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
-#        end
-#    end
-#end
+@static if gmsh_provider == "system"
+    using Libdl
+    function __init__()
+        @static if Sys.isunix()
+            @show gmsh.lib
+            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
+        end
+    end
+end
 
 """
     Gmsh.use_gmsh_jll()

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -35,11 +35,9 @@ export gmsh
 
 @static if gmsh_provider == "system"
     using Libdl
-    # The definition of __init__ is taken from GridapGmsh.jl
     function __init__()
         @static if Sys.isunix()
-            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
-            println("gmsh.lib loaded")
+            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
         end
     end
 end

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -18,26 +18,28 @@ end
 
 @static if gmsh_provider == "gmsh_jll"
     import gmsh_jll
-    gmsh_api = gmsh_jll.gmsh_api
+    const gmsh_api = gmsh_jll.gmsh_api
 end
 
 @static if gmsh_provider == "system"
-    gmsh_jl_dir = @load_preference("gmsh_jl_dir","") 
+    const gmsh_jl_dir = @load_preference("gmsh_jl_dir","") 
     if gmsh_jl_dir == ""
         error("Using a system gmsh installation but gmsh_jl_dir not found in Preferences.toml file")
     end
-    gmsh_api = joinpath(gmsh_jl_dir,"gmsh.jl")
+    const gmsh_api = joinpath(gmsh_jl_dir,"gmsh.jl")
 end
 
 include(gmsh_api)
+import .gmsh
+export gmsh
 
 @static if gmsh_provider == "system"
     using Libdl
     # The definition of __init__ is taken from GridapGmsh.jl
     function __init__()
-        @show Sys.isunix()
         @static if Sys.isunix()
             Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_GLOBAL)
+            println("gmsh.lib loaded")
         end
     end
 end
@@ -129,9 +131,6 @@ function use_system_gmsh(;gmsh_jl_dir=nothing)
     nothing
 end
 
-import .gmsh
-export gmsh
-
 """
     Gmsh.initialize(argv=String[]; finalize_atexit=true)
 
@@ -179,4 +178,4 @@ function finalize()
     end
 end
 
-end
+end # module

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -33,14 +33,14 @@ include(gmsh_api)
 import .gmsh
 export gmsh
 
-@static if gmsh_provider == "system"
-    using Libdl
-    function __init__()
-        @static if Sys.isunix()
-            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
-        end
-    end
-end
+#@static if gmsh_provider == "system"
+#    using Libdl
+#    function __init__()
+#        @static if Sys.isunix()
+#            Libdl.dlopen(gmsh.lib, Libdl.RTLD_LAZY | Libdl.RTLD_DEEPBIND)
+#        end
+#    end
+#end
 
 """
     Gmsh.use_gmsh_jll()

--- a/src/Gmsh.jl
+++ b/src/Gmsh.jl
@@ -41,13 +41,13 @@ include(gmsh_api)
     end
 end
 
-@static if VERSION >= v"1.6"
-    """
-        Gmsh.use_gmsh_jll()
+"""
+    Gmsh.use_gmsh_jll()
 
-    Configure Gmsh to use the binary provided by gmsh_jll.
-    """
-    function use_gmsh_jll()
+Configure Gmsh to use the binary provided by gmsh_jll.
+"""
+function use_gmsh_jll()
+    @static if VERSION >= v"1.6"
         gmsh_provider = "gmsh_jll"
         @set_preferences!(
                           "gmsh_provider"=>gmsh_provider,
@@ -59,20 +59,20 @@ end
         Restart Julia for these changes to take effect.
         """
         @info msg
-        nothing
     end
+    nothing
 end
 
-@static if VERSION >= v"1.6"
-    """
-        Gmsh.use_system_gmsh([;gmsh_jl_dir])
-    
-    Configure Gmsh to use the binary provided by a system installation.
-    Key-word argument `gmsh_jl_dir` contains the path of the directory containing `gmsh.jl`, the file with
-    the Julia API of gmsh. This file needs to be installed as part of the SDK of gmsh.
-    If `gmsh_jl_dir` is omitted, this function will look for `gmsh.jl` in `LD_LIBRARY_PATH`.
-    """
-    function use_system_gmsh(;gmsh_jl_dir=nothing)
+"""
+    Gmsh.use_system_gmsh([;gmsh_jl_dir])
+
+Configure Gmsh to use the binary provided by a system installation.
+Key-word argument `gmsh_jl_dir` contains the path of the directory containing `gmsh.jl`, the file with
+the Julia API of gmsh. This file needs to be installed as part of the SDK of gmsh.
+If `gmsh_jl_dir` is omitted, this function will look for `gmsh.jl` in `LD_LIBRARY_PATH`.
+"""
+function use_system_gmsh(;gmsh_jl_dir=nothing)
+    @static if VERSION >= v"1.6"
         function findindir(route,fn)
             files = readdir(route,join=false)
             for file in files
@@ -98,14 +98,14 @@ end
         if gmsh_jl_dir === nothing
             msg = """
             Unable to find a Gmsh installation in the system.
-    
+
             We looked for the Gmsh Julia API file gmsh.jl in the folders in LD_LIBRARY_PATH.
-    
+
             You can also manualy specify the route with the key-word argument gmsh_jl_dir.
-    
+
             Example
             =======
-    
+
             julia> using Gmsh
             julia> using Gmsh.use_system_gmsh(;gmsh_jl_dir="path/to/gmsh.jl")
             """
@@ -119,13 +119,13 @@ end
         msg = """
         Gmsh preferences changed!
         The new preferences are:
-            gmsh_provider = $(gmsh_provider)
-            gmsh_jl_dir = $(gmsh_jl_dir)
+        gmsh_provider = $(gmsh_provider)
+        gmsh_jl_dir = $(gmsh_jl_dir)
         Restart Julia for these changes to take effect.
         """
         @info msg
-        nothing
     end
+    nothing
 end
 
 import .gmsh


### PR DESCRIPTION
Hi there!

This PR allows users to use their custom installation of Gmsh. The new logic is implemented using Preferences.jl

Two new functions are added
- `Gmsh.use_system_gmsh`. Calling this function will configure Gmsh to use a system installation. It will look for an installation in the system (`LD_LIBRARY_PATH`), or the user can provide the path to the installation. Changes will be effective in the next Julia session.
- `Gmsh.use_gmsh_jll`. Calling this function will configure Gmsh to use the binary provided by `gmsh_jll` (e.g., to revert a previous call to `Gmsh.use_system_gmsh`). Changes will be effective in the next Julia session.

The CI is updated to test Gmsh.jl with a custom installation of Gmsh.
